### PR TITLE
bugfix: do not return an error if the ListModels() call succeeds, but the model is not found

### DIFF
--- a/models.go
+++ b/models.go
@@ -33,7 +33,7 @@ func (c *Gollama) HasModel(model string) (bool, error) {
 		}
 	}
 
-	return false, errors.New("model not found")
+	return false, nil
 }
 
 // ModelSize returns the size of a model on the server.

--- a/models_test.go
+++ b/models_test.go
@@ -48,6 +48,13 @@ func TestGollama_HasModel(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name:    "HasModel",
+			c:       New("llama3.2"),
+			args:    args{model: "notamodel"},
+			want:    false,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
this PR updates the logic to match the comment for HasModel(): https://github.com/jonathanhecl/gollama/blob/main/models.go#L23