### PR TITLE
add client-side context arguments to all functions using GET and POST calls to Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ Easy Ollama package for Golang
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jonathanhecl/gollama"
 )
 
 func main() {
+	ctx := context.Background()
 	g := gollama.New("llama3.2")
 	g.Verbose = true
-	if err := g.PullIfMissing(); err != nil {
+	if err := g.PullIfMissing(ctx); err != nil {
 		fmt.Println("Error:", err)
 		return
 	}
@@ -33,7 +35,7 @@ func main() {
 
 	fmt.Printf("Option: %+v\n", option)
 
-	output, err := g.Chat(prompt, option)
+	output, err := g.Chat(ctx, prompt, option)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return

--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package gollama
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -22,17 +23,22 @@ import (
 //
 // If the request fails, or the response cannot be unmarshaled, an error
 // is returned.
-func (c *Gollama) apiGet(path string, v interface{}) error {
+func (c *Gollama) apiGet(ctx context.Context, path string, v interface{}) error {
 	url, _ := url.JoinPath(c.ServerAddr, path)
 	if c.Verbose {
 		fmt.Printf("Sending a request to GET %s\n", url)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
 	}
 
 	HTTPClient := &http.Client{
 		Timeout: c.HTTPTimeout,
 	}
 
-	resp, err := HTTPClient.Get(url)
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -56,7 +62,7 @@ func (c *Gollama) apiGet(path string, v interface{}) error {
 //
 // The HTTPTimeout is used as the timeout for the HTTP request, except for
 // requests to the /api/pull endpoint, which is given the PullTimeout.
-func (c *Gollama) apiPost(path string, v interface{}, data interface{}) error {
+func (c *Gollama) apiPost(ctx context.Context, path string, v interface{}, data interface{}) error {
 	url, _ := url.JoinPath(c.ServerAddr, path)
 	if c.Verbose {
 		fmt.Printf("Sending a request to POST %s\n", url)
@@ -67,6 +73,13 @@ func (c *Gollama) apiPost(path string, v interface{}, data interface{}) error {
 		return err
 	}
 
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
 	HTTPClient := &http.Client{
 		Timeout: c.HTTPTimeout,
 	}
@@ -75,7 +88,7 @@ func (c *Gollama) apiPost(path string, v interface{}, data interface{}) error {
 		HTTPClient.Timeout = c.PullTimeout
 	}
 
-	resp, err := HTTPClient.Post(url, "application/json", bytes.NewBuffer(reqBytes))
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/chat.go
+++ b/chat.go
@@ -1,6 +1,7 @@
 package gollama
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -18,7 +19,7 @@ type ChatOption interface{}
 // The function returns a pointer to a ChatOuput object, which contains the response to the prompt,
 // as well as some additional information about the response. If an error occurs, the function
 // returns nil and an error.
-func (c *Gollama) Chat(prompt string, options ...ChatOption) (*ChatOuput, error) {
+func (c *Gollama) Chat(ctx context.Context, prompt string, options ...ChatOption) (*ChatOuput, error) {
 	var (
 		temperature   float64
 		seed          = c.SeedOrNegative
@@ -103,7 +104,7 @@ func (c *Gollama) Chat(prompt string, options ...ChatOption) (*ChatOuput, error)
 	// fmt.Printf("Chat request : %+v\n", req)
 
 	var resp chatResponse
-	err := c.apiPost("/api/chat", &resp, req)
+	err := c.apiPost(ctx, "/api/chat", &resp, req)
 	if err != nil {
 		return nil, err
 	}

--- a/chat_test.go
+++ b/chat_test.go
@@ -1,6 +1,7 @@
 package gollama
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 )
@@ -90,7 +91,7 @@ func TestGollama_Chat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.c.Verbose = true
-			got, err := tt.c.Chat(tt.args.Prompt, tt.args.Options)
+			got, err := tt.c.Chat(context.Background(), tt.args.Prompt, tt.args.Options)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.Chat() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/embedding.go
+++ b/embedding.go
@@ -1,6 +1,9 @@
 package gollama
 
-import "math"
+import (
+	"context"
+	"math"
+)
 
 // Embedding generates a vector embedding for a given string of text using the
 // currently set model. The model must support the "embeddings" capability.
@@ -11,14 +14,14 @@ import "math"
 //
 // The function returns a slice of floats, representing the vector
 // embedding of the input text.
-func (c *Gollama) Embedding(prompt string) ([]float64, error) {
+func (c *Gollama) Embedding(ctx context.Context, prompt string) ([]float64, error) {
 	req := embeddingsRequest{
 		Model:  c.ModelName,
 		Prompt: prompt,
 	}
 
 	var resp embeddingsResponse
-	err := c.apiPost("/api/embeddings", &resp, req)
+	err := c.apiPost(ctx, "/api/embeddings", &resp, req)
 	if err != nil {
 		return nil, err
 	}

--- a/embedding_test.go
+++ b/embedding_test.go
@@ -1,6 +1,7 @@
 package gollama
 
 import (
+	"context"
 	"testing"
 )
 
@@ -25,7 +26,7 @@ func TestGollama_Embedding(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.c.Embedding(tt.args.Prompt)
+			got, err := tt.c.Embedding(context.Background(), tt.args.Prompt)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.Embedding() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/models_test.go
+++ b/models_test.go
@@ -1,6 +1,7 @@
 package gollama
 
 import (
+	"context"
 	"testing"
 )
 
@@ -18,7 +19,7 @@ func TestGollama_ListModels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.c.ListModels()
+			got, err := tt.c.ListModels(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.ListModels() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -58,7 +59,7 @@ func TestGollama_HasModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.c.HasModel(tt.args.model)
+			got, err := tt.c.HasModel(context.Background(), tt.args.model)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.HasModel() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -86,10 +87,10 @@ func TestGollama_PullModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.c.PullModel(tt.model); (err != nil) != tt.wantErr {
+			if err := tt.c.PullModel(context.Background(), tt.model); (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.PullModel() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if r, _ := tt.c.HasModel(tt.model); !r {
+			if r, _ := tt.c.HasModel(context.Background(), tt.model); !r {
 				t.Errorf("Gollama.PullModel() = is not downloaded")
 			}
 		})
@@ -115,7 +116,7 @@ func TestGollama_PullIfMissing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.c.PullIfMissing(tt.args.model); (err != nil) != tt.wantErr {
+			if err := tt.c.PullIfMissing(context.Background(), tt.args.model); (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.PullIfMissing() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -141,7 +142,7 @@ func TestGollama_GetDetails(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.c.GetDetails(tt.args.model...)
+			got, err := tt.c.GetDetails(context.Background(), tt.args.model...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.GetDetails() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/version.go
+++ b/version.go
@@ -1,8 +1,10 @@
 package gollama
 
-func (c *Gollama) Version() (string, error) {
+import "context"
+
+func (c *Gollama) Version(ctx context.Context) (string, error) {
 	var resp versionResponse
-	c.apiGet("/api/version", &resp)
+	c.apiGet(ctx, "/api/version", &resp)
 
 	return resp.Version, nil
 }

--- a/version_test.go
+++ b/version_test.go
@@ -1,6 +1,9 @@
 package gollama
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestGollama_Version(t *testing.T) {
 	tests := []struct {
@@ -18,7 +21,7 @@ func TestGollama_Version(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.c.Version()
+			got, err := tt.c.Version(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gollama.Version() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
I'd like to be able to supply a `context.Context{}` to each call in this package that reaches out to Ollama.

This PR adds `context.Context{}` arguments to each of the following functions:
* `Gollama.apiGet`
* `Gollama.apiPost`
* `Gollama.Chat`
* `Gollama.Embedding`
* `Gollama.ListModels`
* `Gollama.HasModel`
* `Gollama.ModelSize`
* `Gollama.PullModel`
* `Gollama.PullIfMissing`
* `Gollama.GetDetails`
* `Gollama.Version`

as well as all related calls to these functions.